### PR TITLE
Use correct version specifier in action

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.0
+        dotnet-version: 5.0.x
     - name: Install dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
`setup-dotnet` requires you to either specify an exact version (e.g. `5.0.100`), or wildcard - but it does support .NET 5 🙂 